### PR TITLE
Add inactivity timeout handling to Codex agent streams

### DIFF
--- a/codex-rs/core/src/error.rs
+++ b/codex-rs/core/src/error.rs
@@ -48,6 +48,12 @@ pub enum CodexErr {
     #[error("timeout waiting for child process to exit")]
     Timeout,
 
+    /// Returned when there has been no activity from the agent stream for a
+    /// configured period of time (e.g., 120 seconds). Treat as a terminal
+    /// error for the current task rather than a transient stream error.
+    #[error("no agent activity for {0} seconds; aborting")]
+    InactivityTimeout(u64),
+
     /// Returned by run_command_stream when the child could not be spawned (its stdout/stderr pipes
     /// could not be captured). Analogous to the previous `CodexError::Spawn` variant.
     #[error("spawn failed: child stdout/stderr not captured")]


### PR DESCRIPTION
## Summary
- Introduces a new `InactivityTimeout` error for detecting agent stream inactivity
- Implements a 120-second inactivity timeout on agent stream event polling
- Treats inactivity timeout as a terminal error, preventing retries
- Sends an error event on inactivity timeout during compact task execution

## Changes

### Core Functionality
- Added `CodexErr::InactivityTimeout` variant to represent inactivity timeout errors
- Wrapped stream event polling with `tokio::time::timeout` to detect inactivity
- Updated `try_run_turn` and `drain_to_completed` functions to return `InactivityTimeout` on timeout
- Modified `run_compact_task` to handle `InactivityTimeout` as terminal and send error event

### Error Handling
- Inactivity timeout is now treated as a terminal error, distinct from transient stream errors
- Prevents retry loops when no activity is detected for the configured timeout period

## Test plan
- Verify that agent streams time out after 120 seconds of inactivity
- Confirm that inactivity timeout errors are propagated and handled correctly
- Ensure no retries occur after inactivity timeout
- Check that error events are sent on inactivity timeout during compact tasks

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/4c555e29-2fe5-440d-a7d5-dfd59429e74e